### PR TITLE
Fix test for Test::Without::Module 0.19

### DIFF
--- a/t/012-without-implementation.t
+++ b/t/012-without-implementation.t
@@ -12,7 +12,7 @@ use Test::Without::Module qw( Class::Load::PP Class::Load::XS );
 {
     like(
         exception { require Class::Load },
-        qr/Class.Load.PP\.pm did not return a true value/,
+        qr!Can't locate Class/Load/PP\.pm in \@INC|Class.Load.PP\.pm did not return a true value!,
         'error when loading Class::Load and no implementation is available includes errors from trying to load modules'
     );
 }


### PR DESCRIPTION
Test::Without::Module changed (Corion/test-without-module@8530c9d1) to make the error message it produces look more like what you'd get if the module was really missing, and this breaks t/012-without-implementation.t in Class-Load and Class-Load-XS.

This pull request changes the test to accept either the old or the new error message.